### PR TITLE
feat: new post router to get filtered posts

### DIFF
--- a/src/controllers/post-controller.ts
+++ b/src/controllers/post-controller.ts
@@ -3,6 +3,7 @@ import postService from "../services/post-service";
 import httpStatus from "http-status";
 import { AuthenticatedRequest } from "../middlewares";
 import { AdminAuthenticatedRequest } from "../middlewares/admin-authentication-middleware";
+import { PostFilters } from "@/repositories/post-repository";
 
 export async function createPost(req: AdminAuthenticatedRequest, res: Response) {
   const { adminId } = req;
@@ -21,6 +22,21 @@ export async function getPosts(req: Request, res: Response) {
     const posts = await postService.getPosts();
 
     return res.status(httpStatus.OK).send(posts);
+  } catch (error) {
+    if (error.name === "NotFoundError") return res.status(httpStatus.NOT_FOUND).send(error);
+
+    return res.sendStatus(httpStatus.INTERNAL_SERVER_ERROR);
+  }
+}
+
+export async function getFilteredPosts(req: Request, res: Response) {
+  const { filterIds } = req.body;
+  const filter = filterIds as PostFilters;
+
+  try {
+    const filteredPosts = await postService.getManyFilteredPosts(filter);
+
+    return res.status(httpStatus.OK).send(filteredPosts);
   } catch (error) {
     if (error.name === "NotFoundError") return res.status(httpStatus.NOT_FOUND).send(error);
 

--- a/src/repositories/post-repository/index.ts
+++ b/src/repositories/post-repository/index.ts
@@ -28,6 +28,37 @@ async function findMany(): Promise<GetPost[]> {
   });
 }
 
+async function findManyByFilteredIds(postFilters: PostFilters): Promise<GetPost[]> {
+  let filter = {
+    where: {}
+  };
+
+  if (postFilters.topicId.length !== 0) {
+      filter.where = {...filter.where, topicId: { in: postFilters.topicId }}
+  }
+
+  return prisma.posts.findMany({
+      ...filter,
+      orderBy:{
+          id: 'desc'
+      },
+      select: {
+        id: true,
+        title: true,
+        topics: true,
+        text: true,
+        image: true,
+        likes: true,
+        admins: {
+          select: {
+            name: true,
+            photo: true,
+          },
+        },
+      },
+    });
+}
+
 async function findById(id: number): Promise<posts> {
   return await prisma.posts.findUnique({
     where: {
@@ -49,6 +80,10 @@ async function updateLikes(id: number, value: number) {
   });
 }
 
+export type PostFilters = {
+  topicId: number[]
+}
+
 export type GetPost = Omit<PostParams, "adminId" | "topicId"> & { admins: { name: string; photo: string } };
 
 export type PostParams = Omit<posts, "id" | "created_at" | "updated_at">;
@@ -58,6 +93,7 @@ const postRepository = {
   findMany,
   findById,
   updateLikes,
+  findManyByFilteredIds
 };
 
 export default postRepository;

--- a/src/routers/post-router.ts
+++ b/src/routers/post-router.ts
@@ -1,4 +1,4 @@
-import { createPost, getPosts, updateLikes } from "../controllers";
+import { createPost, getFilteredPosts, getPosts, updateLikes } from "../controllers";
 import { adminAuthenticateToken, authenticateToken, validateBody, validateParams } from "../middlewares";
 import { createPostSchema, postIdSchema, updateLikeSchema } from "../schemas";
 import { Router } from "express";
@@ -7,6 +7,7 @@ const postRouter = Router();
 
 postRouter
   .get("/", getPosts)
+  .post("/filter", getFilteredPosts)
   .post("/", adminAuthenticateToken, validateBody(createPostSchema), createPost)
   .patch("/:id", authenticateToken, validateParams(postIdSchema), validateBody(updateLikeSchema), updateLikes);
 

--- a/src/services/post-service/index.ts
+++ b/src/services/post-service/index.ts
@@ -1,5 +1,5 @@
 import { notFoundError, unprocessableContent } from "../../errors";
-import postRepository, { GetPost, PostParams } from "../../repositories/post-repository";
+import postRepository, { GetPost, PostFilters, PostParams } from "../../repositories/post-repository";
 
 export async function createPost(postData: PostParams): Promise<void> {
   await postRepository.insert(postData);
@@ -9,6 +9,14 @@ export async function createPost(postData: PostParams): Promise<void> {
 
 export async function getPosts(): Promise<GetPost[]> {
   const posts = await postRepository.findMany();
+
+  if (posts.length === 0) throw notFoundError();
+
+  return posts;
+}
+
+export async function getManyFilteredPosts(postFilters: PostFilters): Promise<GetPost[]> {
+  const posts = await postRepository.findManyByFilteredIds(postFilters);
 
   if (posts.length === 0) throw notFoundError();
 
@@ -30,7 +38,8 @@ export async function updateLikes(postId: number, value: number): Promise<void> 
 const postService = {
   createPost,
   getPosts,
-  updateLikes
+  updateLikes,
+  getManyFilteredPosts
 };
 
 export default postService;


### PR DESCRIPTION
Commit referente a task #54, que tinha prioridade em realizar a filtragem dos posts por meio dos tópicos e renderizar essa filtragem no front.

O que foi mudado/adicionado:
- Criei uma nova rota em "/posts"
- A nova rota POST "/filter" é utilizada com um GET, foi o método que o Yago Tostes(Tutor Driven) e Eu (Esdras) utilizamos para conseguir realizar a filtragem corretamente.