### PR TITLE
fix: post title seed and post repository now return created_at variable

### DIFF
--- a/prisma/blogTexts.ts
+++ b/prisma/blogTexts.ts
@@ -21,9 +21,7 @@ export const textOne = `A forma de transmissão mais comum do vírus HIV, causad
 
             A luta contra a AIDS é de todos, e é diaria, sexo seguro é um direito e deve ser a regra e não a excessão, independente da identidade de gênero, orientação sexual ou sexo biólogico.`;
 
-export const textTwo = `"Você é muito jovem para saber"
-
-	                                        Jovens sempre enfrentam situações em que suas vozes são silenciadas por justificativas sem sentido, sobre como ser jovem os torna incapazes de pensar por si mesmos. Os LGBTQIA+, além disso, muitas vezes são colocados como pessoas confusas, que estão apenas querendo chamar atenção. Sabemos o quão prejudicial isso é para a saúde mental dos jovens da nossa comunidade e podem ter certeza de que já acumulamos traumas demais no processo de aceitação.
+export const textTwo = `Jovens sempre enfrentam situações em que suas vozes são silenciadas por justificativas sem sentido, sobre como ser jovem os torna incapazes de pensar por si mesmos. Os LGBTQIA+, além disso, muitas vezes são colocados como pessoas confusas, que estão apenas querendo chamar atenção. Sabemos o quão prejudicial isso é para a saúde mental dos jovens da nossa comunidade e podem ter certeza de que já acumulamos traumas demais no processo de aceitação.
 					
 						"Na minha época isso não existia!"
 					

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -141,14 +141,14 @@ async function main() {
       data: [
         {
           adminId: admin.id,
-          title: "Título 1",
+          title: "Sorofobia",
           topicId: findTopics[0].id,
           text: textOne,
           image: "https://i.imgur.com/YFby08q.png",
         },
         {
           adminId: admin.id,
-          title: "Título 2",
+          title: `"Você é muito jovem para saber"`,
           topicId: findTopics[1].id,
           text: textTwo,
           image: "https://i.imgur.com/u4Kc3Lu.png",

--- a/src/repositories/post-repository/index.ts
+++ b/src/repositories/post-repository/index.ts
@@ -18,6 +18,7 @@ async function findMany(): Promise<GetPost[]> {
       text: true,
       image: true,
       likes: true,
+      created_at: true,
       admins: {
         select: {
           name: true,
@@ -49,6 +50,7 @@ async function findManyByFilteredIds(postFilters: PostFilters): Promise<GetPost[
         text: true,
         image: true,
         likes: true,
+        created_at: true,
         admins: {
           select: {
             name: true,
@@ -86,7 +88,7 @@ export type PostFilters = {
 
 export type GetPost = Omit<PostParams, "adminId" | "topicId"> & { admins: { name: string; photo: string } };
 
-export type PostParams = Omit<posts, "id" | "created_at" | "updated_at">;
+export type PostParams = Omit<posts, "id" | "updated_at">;
 
 const postRepository = {
   insert,


### PR DESCRIPTION
Commit referente a task #48, que tinha prioridade em alterar o design dos cards do blog do site.

O que foi mudado/adicionado:

- Alterei o seed para colocar o título certo do post
- Alterei o repository e o tipo "GetPosts' para retornar a variável "created_at"